### PR TITLE
Doc: add some information on Chaos "NTFSRT"

### DIFF
--- a/chaos_proto_doc.rs
+++ b/chaos_proto_doc.rs
@@ -1,0 +1,41 @@
+// Copyright  (C) 2023, Kisio Digital and/or its affiliates. All rights reserved.
+//
+// This file is part of Navitia,
+// the software to build cool stuff with public transport.
+//
+// Hope you'll enjoy and contribute to this project,
+// powered by Kisio Digital (www.kisio.com).
+// Help us simplify mobility and open public transport:
+// a non ending quest to the responsive locomotion way of traveling!
+//
+//
+// LICENCE: This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+//
+// Stay tuned using
+// twitter @navitia
+// channel `#navitia` on Element https://app.element.io/#/room/#navitia:matrix.org
+// https://groups.google.com/d/forum/navitia
+// www.navitia.io
+
+pub struct FeedMessage {
+    entity: Vec<FeedEntity>,
+}
+
+pub struct FeedEntity {
+    // Id of the disruption to be added/replaced/deleted
+    // For a same entity id, the last one emitted is always the most up-to-date
+    // (to sort and/or shortcut multiple FeedMessages to process).
+    // It's also stand-alone (contains all the information of the disruption).
+    id: String,
+}

--- a/kirin_proto_doc.rs
+++ b/kirin_proto_doc.rs
@@ -36,6 +36,7 @@ pub struct FeedEntity {
     // Id of the disruption to be added/replaced
     // For a same entity id, the last one emitted is always the most up-to-date
     // (to sort and/or shortcut multiple FeedMessages to process).
+    // It's also stand-alone (contains all the information of the disruption).
     id: String,
 
     // Disruption on a dated-VehicleJourney


### PR DESCRIPTION
Minimalistic documentation init, on a single question. The rest of the fields are still "todo".

Also mini update on Kirin's doc.

Relates to https://navitia.atlassian.net/browse/NAV-1650