### PR TITLE
Refs #BO-2896  - Add name of pt object in chaos proto for mailjet

### DIFF
--- a/chaos.proto
+++ b/chaos.proto
@@ -146,6 +146,7 @@ message PtObject{
     optional LineSection pt_line_section = 5;
     optional RailSection pt_rail_section = 6;
     optional AccessPoint pt_access_point = 7;
+    required string name = 8;
 }
 
 message Severity{


### PR DESCRIPTION
# Description

This PR add name of pt object in PtObject message (protobuf)

# Reference

- https://navitia.atlassian.net/browse/BO-2896 