### PR TITLE
[BO-3775] - Add author of the disruption

### DIFF
--- a/chaos.proto
+++ b/chaos.proto
@@ -25,6 +25,8 @@ message Disruption{
     optional string contributor = 14;
     // properties attached to the disruption
     repeated DisruptionProperty properties = 15;
+    // author of the disruption
+    optional string author = 16;
 }
 
 message Wording {


### PR DESCRIPTION
In order to use the author for the filter part, we should pass it to the proto.