### PR TITLE
Refs #BO-2896  - Edit interface name of pt object in chaos proto for mailjet

### DIFF
--- a/chaos.proto
+++ b/chaos.proto
@@ -148,7 +148,7 @@ message PtObject{
     optional LineSection pt_line_section = 5;
     optional RailSection pt_rail_section = 6;
     optional AccessPoint pt_access_point = 7;
-    required string name = 8;
+    optional string name = 8;
 }
 
 message Severity{


### PR DESCRIPTION
# Description

This PR change the mandatory type about name of pt object in PtObject message (protobuf)

_If we keep `required` navitia will not work._ because when all disruptions are load from database it will be converted on proto object.

# Reference

- https://navitia.atlassian.net/browse/BO-2896 
- https://github.com/hove-io/Chaos/pull/710