### PR TITLE
[BO-3701] - Add field 'type' in disruption object

### DIFF
--- a/chaos.proto
+++ b/chaos.proto
@@ -5,6 +5,8 @@ import "gtfs-realtime.proto";
 message Disruption{
     // must match with the id in the FeedEntity for deletion
     required string id = 1;
+    // indicator if disruption is planned or not
+    optional string type = 2;
     // it's a reference label as shown in the backoffice
     optional string reference = 3;
     // the publication period specify when an information can be displayed to


### PR DESCRIPTION
# Description
This PR adds field 'type' in disruption object. It's an optional field.

# Reference
[BO-3701](https://navitia.atlassian.net/browse/BO-3701)

[BO-3701]: https://navitia.atlassian.net/browse/BO-3701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ