### PR TITLE
[BO-3701] - Add version in Chaos proto

### DIFF
--- a/chaos.proto
+++ b/chaos.proto
@@ -29,6 +29,8 @@ message Disruption{
     repeated DisruptionProperty properties = 15;
     // author of the disruption
     optional string author = 16;
+    // version of the disruption
+    optional string version = 17;
 }
 
 message Wording {
@@ -73,6 +75,8 @@ message Impact{
     optional uint64 notification_date = 9;
     // Application pattern used while creating impact if any
     repeated Pattern application_patterns = 10;
+    // version of the disruption
+    optional string version = 11;
 }
 
 message WeekPattern {

--- a/chaos.proto
+++ b/chaos.proto
@@ -75,7 +75,7 @@ message Impact{
     optional uint64 notification_date = 9;
     // Application pattern used while creating impact if any
     repeated Pattern application_patterns = 10;
-    // version of the disruption
+    // version of the impact
     optional string version = 11;
 }
 


### PR DESCRIPTION
# Description
Thsi PR adds optional field s`version` in Chaos protobuf into Disruption and Impacts objects

# Reference
[BO-3701](https://navitia.atlassian.net/browse/BO-3701)

[BO-3701]: https://navitia.atlassian.net/browse/BO-3701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ